### PR TITLE
Change polygon tool closing behaviour

### DIFF
--- a/app/classifier/drawing-tools/polygon.cjsx
+++ b/app/classifier/drawing-tools/polygon.cjsx
@@ -90,7 +90,6 @@ module.exports = createReactClass
           {unless @props.mark.closed
             <g>
               <circle className="clickable" r={finisherRadius} cx={firstPoint.x} cy={firstPoint.y} stroke="transparent" onClick={@handleFinishClick} />
-              <circle className="clickable" r={finisherRadius} cx={lastPoint.x} cy={lastPoint.y} onClick={@handleFinishClick} />
             </g>}
         </g>}
     </DrawingToolRoot>


### PR DESCRIPTION
When using the polygon tool, clicking the last point drawn used to close the shape. Now, it acts like the other points (i.e. becomes draggable) - the only way to close a polygon now is to click on the first point drawn.

Fix #19 