### PR TITLE
Custom queue

### DIFF
--- a/app/classifier/task-nav.jsx
+++ b/app/classifier/task-nav.jsx
@@ -91,11 +91,14 @@ class TaskNav extends React.Component {
       nextTaskKey = '';
     }
 
-    const showDoneAndTalkLink = !nextTaskKey &&
-      this.props.workflow.configuration.hide_classification_summaries &&
-      this.props.project &&
-      !disableTalk &&
-      !completed;
+    // const showDoneAndTalkLink = !nextTaskKey &&
+    //   this.props.workflow.configuration.hide_classification_summaries &&
+    //   this.props.project &&
+    //   !disableTalk &&
+    //   !completed;
+
+    // We never want to show it.
+    const showDoneAndTalkLink = false;
 
     return (
       <div>

--- a/app/crowd_handler.js
+++ b/app/crowd_handler.js
@@ -20,12 +20,17 @@ import qs from 'qs'
 
 class NoopHandler {
   constructor(queryParams) {
+    this._classificationIds = []
     this._queryParams = queryParams
     this.previewMode = false
     console.group('1715 Labs Crowd Handler config')
     console.info('CLICKWORKER_POSTBACK_URL', process.env.CLICKWORKER_POSTBACK_URL)
     console.info('MTURK_POSTBACK_URL', process.env.MTURK_POSTBACK_URL)
     console.groupEnd()
+  }
+
+  addClassificationId(id) {
+    this._classificationIds.push(id)
   }
 
   // Extract the keys passed via the arguments from the queryParams property, and return as
@@ -48,9 +53,8 @@ class NoopHandler {
   }
 
   // Trigger the postback process for completing a task on the crowd platform.
-  triggerCallback(classification) {
+  triggerCallback() {
     console.info('NoopHandler, so nothing to do here')
-    console.info('Classification:', classification)
     return
   }
 }
@@ -63,9 +67,9 @@ class ClickworkerHandler extends NoopHandler {
     }
   }
 
-  triggerCallback(classification) {
+  triggerCallback() {
     const redirectQueryParams = {
-      'classification_id': classification.id,
+      'classification_ids': this._classificationIds.join(','),
       'job_id': this._queryParams['job_id'],
       'task_id': this._queryParams['task_id'],
       'user_id': this._queryParams['user_id'],
@@ -119,9 +123,9 @@ class MTurkHandler extends NoopHandler {
     form.submit();
   }
 
-  triggerCallback(classification) {
+  triggerCallback() {
     const assignmentId = this._queryParams['assignmentId']
-    const classificationId = classification.id
+    const classificationIds = this._classificationIds.join(',')
 
     if (!assignmentId) {
       console.error('MTurk `assignmentId` not found, skipping postback')
@@ -129,7 +133,7 @@ class MTurkHandler extends NoopHandler {
     }
 
     const path = process.env.MTURK_POSTBACK_URL
-    this.createFormAndPost(path, { assignmentId, classificationId });
+    this.createFormAndPost(path, { assignmentId, classificationIds });
   }
 }
 

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -6,7 +6,7 @@ export default {
     close: 'Close',
     continue: 'Continue',
     detailsSubTaskFormSubmitButton: 'OK',
-    done: 'Done',
+    done: 'Next',
     doneAndTalk: 'Done & Talk',
     dontShowMinicourse: 'Do not show mini-course in the future',
     letsGo: 'Let’s go!',

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -268,7 +268,7 @@ export class ProjectClassifyPage extends React.Component {
     const subject = upcomingSubjects[0];
 
     if (!subject) {
-      return (<span>Finished, please wait...</span>)
+      return (<span>Loading, please wait...</span>)
     }
 
     if (classification && classification.links.workflow === workflow.id) {

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -37,7 +37,7 @@ window.addEventListener('beforeunload', e => {
 
 function onClassificationSaved(actualClassification) {
   Split.classificationCreated(actualClassification); // Metric log needs classification id
-  crowdHandler.triggerCallback(actualClassification);
+  crowdHandler.addClassificationId(actualClassification.id);
 }
 
 function isPresent(val) {
@@ -107,8 +107,13 @@ export class ProjectClassifyPage extends React.Component {
 
     if (upcomingSubjects.length !== prevProps.upcomingSubjects.length) {
       // Refill the subject queue when we're down to the last subject in the current batch.
-      if (upcomingSubjects.length < 2) {
-        this.refillSubjectQueue();
+      // But since we're in MTurk mode, we don't actually want that
+      // if (upcomingSubjects.length < 2) {
+      //   this.refillSubjectQueue();
+      // }
+      if (upcomingSubjects.length === 0) {
+        console.info('No more subjects in the queue, triggering crowd callback...')
+        crowdHandler.triggerCallback()
       }
     }
 
@@ -261,6 +266,11 @@ export class ProjectClassifyPage extends React.Component {
     const { classification, upcomingSubjects, workflow } = this.props;
     const { demoMode } = this.state;
     const subject = upcomingSubjects[0];
+
+    if (!subject) {
+      return (<span>Finished, please wait...</span>)
+    }
+
     if (classification && classification.links.workflow === workflow.id) {
       return (
         <Classifier

--- a/css/1715labs.styl
+++ b/css/1715labs.styl
@@ -1,8 +1,8 @@
 .app-layout__header,         // Main Zooniverse header
 .app-layout__footer,         // Main Zooniverse footer
 .project-page > header,      // Project header
-a[href*="/talk/"],           // Any Talk links
-a[href*="/talk/"] + button   // Final 'Next' button
+a[href*="/talk/"]           // Any Talk links
+// a[href*="/talk/"] + button   // Final 'Next' button
   display: none !important
 
 // Unwanted toolbar buttons under subject viewer are hidden in `subject-viewer.cjsx`


### PR DESCRIPTION
This PR refactors the existing classification lifecycle to handle multiple subjects provided by a URL query param:

- Restore the previous and next buttons hidden via CSS
- Existing subject queue code repurposed to construct a queue of one or more subjects when subject IDs are found in the URL
- Fallback to the `/subjects/queued` endpoint now only provides a single subject
- Subject queue now no longer refills automatically
- Crowd provider callback is now called when there are no more subjects in the queue, as opposed to at the end of a single classification
- Multiple classification IDs are now appended to the crowd provider callback payload

@tingard when you're free, I want to try running through this with you on MTurk